### PR TITLE
Vendor argwhere

### DIFF
--- a/dask_ndmeasure/_compat.py
+++ b/dask_ndmeasure/_compat.py
@@ -77,7 +77,9 @@ _isnonzero_vec = numpy.vectorize(_isnonzero_vec, otypes=[bool])
 
 
 def _isnonzero(a):
-    a = dask.array.asarray(a)
+    if not isinstance(a, dask.array.Array):
+        a = numpy.asarray(a)
+        a = dask.array.from_array(a, a.shape)
 
     try:
         numpy.zeros(tuple(), dtype=a.dtype).astype(bool)

--- a/dask_ndmeasure/_compat.py
+++ b/dask_ndmeasure/_compat.py
@@ -99,6 +99,21 @@ def _argwhere(a):
         ind = dask.array.stack(
             [ind[i].ravel() for i in range(len(ind))], axis=1
         )
-    ind = dask.array.compress(nz, ind, axis=0)
+
+    axis = 0
+    axes = tuple(range(ind.ndim))
+
+    ind = dask.array.atop(
+        numpy.compress, axes,
+        nz, (axis,),
+        ind, axes,
+        axis=axis,
+        dtype=ind.dtype,
+    )
+    ind._chunks = (
+        ind.chunks[:axis] +
+        (len(ind.chunks[axis]) * (numpy.nan,),) +
+        ind.chunks[axis+1:]
+    )
 
     return ind

--- a/dask_ndmeasure/_compat.py
+++ b/dask_ndmeasure/_compat.py
@@ -67,3 +67,10 @@ def _indices(dimensions, dtype=int, chunks=None):
         )
 
     return grid
+
+
+def _isnonzero_vec(v):
+    return bool(numpy.count_nonzero(v))
+
+
+_isnonzero_vec = numpy.vectorize(_isnonzero_vec, otypes=[bool])

--- a/dask_ndmeasure/_compat.py
+++ b/dask_ndmeasure/_compat.py
@@ -74,3 +74,14 @@ def _isnonzero_vec(v):
 
 
 _isnonzero_vec = numpy.vectorize(_isnonzero_vec, otypes=[bool])
+
+
+def _isnonzero(a):
+    a = dask.array.asarray(a)
+
+    try:
+        numpy.zeros(tuple(), dtype=a.dtype).astype(bool)
+    except ValueError:
+        return a.map_blocks(_isnonzero_vec, dtype=bool)
+    else:
+        return a.astype(bool)

--- a/dask_ndmeasure/_compat.py
+++ b/dask_ndmeasure/_compat.py
@@ -78,10 +78,6 @@ _isnonzero_vec = numpy.vectorize(_isnonzero_vec, otypes=[bool])
 
 
 def _isnonzero(a):
-    if not isinstance(a, dask.array.Array):
-        a = numpy.asarray(a)
-        a = dask.array.from_array(a, a.shape)
-
     try:
         numpy.zeros(tuple(), dtype=a.dtype).astype(bool)
     except ValueError:
@@ -92,6 +88,10 @@ def _isnonzero(a):
 
 @functools.wraps(numpy.argwhere)
 def _argwhere(a):
+    if not isinstance(a, dask.array.Array):
+        a = numpy.asarray(a)
+        a = dask.array.from_array(a, a.shape)
+
     nz = _isnonzero(a).flatten()
 
     ind = _indices(a.shape, dtype=numpy.int64, chunks=a.chunks)

--- a/dask_ndmeasure/_compat.py
+++ b/dask_ndmeasure/_compat.py
@@ -1,1 +1,69 @@
 # -*- coding: utf-8 -*-
+
+
+import itertools
+
+import numpy
+
+import dask.array
+
+
+def _indices(dimensions, dtype=int, chunks=None):
+    """
+    Implements NumPy's ``indices`` for Dask Arrays.
+    Generates a grid of indices covering the dimensions provided.
+    The final array has the shape ``(len(dimensions), *dimensions)``. The
+    chunks are used to specify the chunking for axis 1 up to
+    ``len(dimensions)``. The 0th axis always has chunks of length 1.
+
+    Parameters
+    ----------
+    dimensions : sequence of ints
+        The shape of the index grid.
+    dtype : dtype, optional
+        Type to use for the array. Default is ``int``.
+    chunks : sequence of ints
+        The number of samples on each block. Note that the last block will
+        have fewer samples if ``len(array) % chunks != 0``.
+
+    Returns
+    -------
+    grid : dask array
+
+    Notes
+    -----
+    Borrowed from my Dask Array contribution.
+    """
+    if chunks is None:
+        raise ValueError("Must supply a chunks= keyword argument")
+
+    dimensions = tuple(dimensions)
+    dtype = numpy.dtype(dtype)
+    chunks = tuple(chunks)
+
+    if len(dimensions) != len(chunks):
+        raise ValueError("Need one more chunk than dimensions.")
+
+    grid = []
+    if numpy.prod(dimensions):
+        for i in range(len(dimensions)):
+            s = len(dimensions) * [None]
+            s[i] = slice(None)
+            s = tuple(s)
+
+            r = dask.array.arange(dimensions[i], dtype=dtype, chunks=chunks[i])
+            r = r[s]
+
+            for j in itertools.chain(range(i), range(i + 1, len(dimensions))):
+                r = r.repeat(dimensions[j], axis=j)
+
+            grid.append(r)
+
+    if grid:
+        grid = dask.array.stack(grid)
+    else:
+        grid = dask.array.empty(
+            (len(dimensions),) + dimensions, dtype=dtype, chunks=(1,) + chunks
+        )
+
+    return grid

--- a/tests/test__compat.py
+++ b/tests/test__compat.py
@@ -8,6 +8,7 @@ import pytest
 import numpy as np
 
 import dask
+import dask.array as da
 import dask.array.utils as dau
 
 import dask_ndmeasure._compat
@@ -69,3 +70,34 @@ def test_indicies():
     darr = dask_ndmeasure._compat._indices((2, 3), chunks=(1, 2))
     nparr = np.indices((2, 3))
     dau.assert_eq(darr, nparr)
+
+
+def test_argwhere():
+    for shape, chunks in [(0, ()), ((0, 0), (0, 0)), ((15, 16), (4, 5))]:
+        x = np.random.randint(10, size=shape)
+        d = da.from_array(x, chunks=chunks)
+
+        x_nz = np.argwhere(x)
+        d_nz = dask_ndmeasure._compat._argwhere(d)
+
+        dau.assert_eq(d_nz, x_nz)
+
+
+def test_argwhere_obj():
+    x = np.random.randint(10, size=(15, 16)).astype(object)
+    d = da.from_array(x, chunks=(4, 5))
+
+    x_nz = np.argwhere(x)
+    d_nz = dask_ndmeasure._compat._argwhere(d)
+
+    dau.assert_eq(d_nz, x_nz)
+
+
+def test_argwhere_str():
+    x = np.array(list("Hello world"))
+    d = da.from_array(x, chunks=(4,))
+
+    x_nz = np.argwhere(x)
+    d_nz = dask_ndmeasure._compat._argwhere(d)
+
+    dau.assert_eq(d_nz, x_nz)

--- a/tests/test__compat.py
+++ b/tests/test__compat.py
@@ -74,7 +74,7 @@ def test_indicies():
 
 
 @pytest.mark.parametrize("shape, chunks", [
-    (0, ()), ((0, 0), (0, 0)), ((15, 16), (4, 5))
+    (0, ()), ((0, 0), (0, 0)), ((15, 16), (15, 16))
 ])
 def test_argwhere(shape, chunks):
     if not np.prod(shape) and not dask_0_14_1:

--- a/tests/test__compat.py
+++ b/tests/test__compat.py
@@ -1,1 +1,71 @@
 # -*- coding: utf-8 -*-
+
+
+import distutils.version as ver
+
+import pytest
+
+import numpy as np
+
+import dask
+import dask.array.utils as dau
+
+import dask_ndmeasure._compat
+
+
+old_dask = ver.LooseVersion(dask.__version__) <= ver.LooseVersion("0.13.0")
+
+
+def test_indices_no_chunks():
+    with pytest.raises(ValueError):
+        dask_ndmeasure._compat._indices((1,))
+
+
+def test_indices_wrong_chunks():
+    with pytest.raises(ValueError):
+        dask_ndmeasure._compat._indices((1,), chunks=tuple())
+
+
+@pytest.mark.parametrize(
+    "dimensions, dtype, chunks",
+    [
+        (tuple(), int, tuple()),
+        (tuple(), float, tuple()),
+        ((0,), float, (1,)),
+        ((0, 1, 2), float, (1, 1, 2)),
+    ]
+)
+def test_empty_indicies(dimensions, dtype, chunks):
+    darr = dask_ndmeasure._compat._indices(dimensions, dtype, chunks=chunks)
+    nparr = np.indices(dimensions, dtype)
+
+    assert darr.shape == nparr.shape
+    assert darr.dtype == nparr.dtype
+
+    try:
+        dau.assert_eq(darr, nparr)
+    except IndexError:
+        if len(dimensions) and old_dask:
+            pytest.skip(
+                "Dask pre-0.14.0 is unable to compute this empty array."
+            )
+        else:
+            raise
+
+
+def test_indicies():
+    darr = dask_ndmeasure._compat._indices((1,), chunks=(1,))
+    nparr = np.indices((1,))
+    dau.assert_eq(darr, nparr)
+
+    darr = dask_ndmeasure._compat._indices((1,), float, chunks=(1,))
+    nparr = np.indices((1,), float)
+    dau.assert_eq(darr, nparr)
+
+    darr = dask_ndmeasure._compat._indices((2, 1), chunks=(2, 1))
+    nparr = np.indices((2, 1))
+    dau.assert_eq(darr, nparr)
+
+    darr = dask_ndmeasure._compat._indices((2, 3), chunks=(1, 2))
+    nparr = np.indices((2, 3))
+    dau.assert_eq(darr, nparr)

--- a/tests/test__compat.py
+++ b/tests/test__compat.py
@@ -91,6 +91,15 @@ def test_argwhere(shape, chunks):
     dau.assert_eq(d_nz, x_nz)
 
 
+def test_argwhere_arr():
+    x = np.random.randint(10, size=(15, 16)).astype(object)
+
+    x_nz = np.argwhere(x)
+    d_nz = dask_ndmeasure._compat._argwhere(x)
+
+    dau.assert_eq(d_nz, x_nz)
+
+
 @pytest.mark.skipif(
     not dask_0_14_1,
     reason="Dask pre-0.14.1 is unable to compute this object array."

--- a/tests/test__compat.py
+++ b/tests/test__compat.py
@@ -72,15 +72,17 @@ def test_indicies():
     dau.assert_eq(darr, nparr)
 
 
-def test_argwhere():
-    for shape, chunks in [(0, ()), ((0, 0), (0, 0)), ((15, 16), (4, 5))]:
-        x = np.random.randint(10, size=shape)
-        d = da.from_array(x, chunks=chunks)
+@pytest.mark.parametrize("shape, chunks", [
+    (0, ()), ((0, 0), (0, 0)), ((15, 16), (4, 5))
+])
+def test_argwhere(shape, chunks):
+    x = np.random.randint(10, size=shape)
+    d = da.from_array(x, chunks=chunks)
 
-        x_nz = np.argwhere(x)
-        d_nz = dask_ndmeasure._compat._argwhere(d)
+    x_nz = np.argwhere(x)
+    d_nz = dask_ndmeasure._compat._argwhere(d)
 
-        dau.assert_eq(d_nz, x_nz)
+    dau.assert_eq(d_nz, x_nz)
 
 
 def test_argwhere_obj():

--- a/tests/test__compat.py
+++ b/tests/test__compat.py
@@ -14,7 +14,8 @@ import dask.array.utils as dau
 import dask_ndmeasure._compat
 
 
-old_dask = ver.LooseVersion(dask.__version__) <= ver.LooseVersion("0.13.0")
+dask_0_14_0 = ver.LooseVersion(dask.__version__) >= ver.LooseVersion("0.14.0")
+dask_0_14_1 = ver.LooseVersion(dask.__version__) >= ver.LooseVersion("0.14.1")
 
 
 def test_indices_no_chunks():
@@ -46,7 +47,7 @@ def test_empty_indicies(dimensions, dtype, chunks):
     try:
         dau.assert_eq(darr, nparr)
     except IndexError:
-        if len(dimensions) and old_dask:
+        if len(dimensions) and not dask_0_14_0:
             pytest.skip(
                 "Dask pre-0.14.0 is unable to compute this empty array."
             )
@@ -76,6 +77,11 @@ def test_indicies():
     (0, ()), ((0, 0), (0, 0)), ((15, 16), (4, 5))
 ])
 def test_argwhere(shape, chunks):
+    if not np.prod(shape) and not dask_0_14_1:
+        pytest.skip(
+            "Dask pre-0.14.1 is unable to compute this empty array."
+        )
+
     x = np.random.randint(10, size=shape)
     d = da.from_array(x, chunks=chunks)
 
@@ -85,6 +91,10 @@ def test_argwhere(shape, chunks):
     dau.assert_eq(d_nz, x_nz)
 
 
+@pytest.mark.skipif(
+    not dask_0_14_1,
+    reason="Dask pre-0.14.1 is unable to compute this object array."
+)
 def test_argwhere_obj():
     x = np.random.randint(10, size=(15, 16)).astype(object)
     d = da.from_array(x, chunks=(4, 5))


### PR DESCRIPTION
Provides a vendored copy of `argwhere` based on our contribution to Dask with a few tweaks. In particular, may a tweak to use `atop` instead of `compress` as no released version of Dask has a lazy implementation for `compress`. This draws inspiration from a similar change made upstream, but is simplified significantly. Unfortunately requires a hack to get the chunks right. Seems to work ok though based on local experimentation.

Also vendors a few other things that `argwhere` depends on like `indices`, which are based on our Dask contributions as well. Similarly includes the tests that we contributed to Dask. Some tests are skipped on older Dask versions as they don't work properly. However the tests skipped are unlikely to come up in any context where these vendored functions will be used. 