### PR TITLE
Refactor _asarray

### DIFF
--- a/dask_ndmeasure/_compat.py
+++ b/dask_ndmeasure/_compat.py
@@ -9,6 +9,27 @@ import numpy
 import dask.array
 
 
+def _asarray(a):
+    """
+    Creates a Dask array based on ``a``.
+
+    Parameters
+    ----------
+    a : array-like
+        Object to convert to a Dask Array.
+
+    Returns
+    -------
+    a : Dask Array
+    """
+
+    if not isinstance(a, dask.array.Array):
+        a = numpy.asarray(a)
+        a = dask.array.from_array(a, a.shape)
+
+    return a
+
+
 def _indices(dimensions, dtype=int, chunks=None):
     """
     Implements NumPy's ``indices`` for Dask Arrays.
@@ -88,9 +109,7 @@ def _isnonzero(a):
 
 @functools.wraps(numpy.argwhere)
 def _argwhere(a):
-    if not isinstance(a, dask.array.Array):
-        a = numpy.asarray(a)
-        a = dask.array.from_array(a, a.shape)
+    a = _asarray(a)
 
     nz = _isnonzero(a).flatten()
 

--- a/tests/test__compat.py
+++ b/tests/test__compat.py
@@ -18,6 +18,22 @@ dask_0_14_0 = ver.LooseVersion(dask.__version__) >= ver.LooseVersion("0.14.0")
 dask_0_14_1 = ver.LooseVersion(dask.__version__) >= ver.LooseVersion("0.14.1")
 
 
+@pytest.mark.parametrize("x", [
+    list(range(5)),
+    np.random.randint(10, size=(15, 16)),
+    da.random.randint(10, size=(15, 16), chunks=(5, 5)),
+])
+def test_asarray(x):
+    d = dask_ndmeasure._compat._asarray(x)
+
+    assert isinstance(d, da.Array)
+
+    if not isinstance(x, (np.ndarray, da.Array)):
+        x = np.asarray(x)
+
+    dau.assert_eq(d, x)
+
+
 def test_indices_no_chunks():
     with pytest.raises(ValueError):
         dask_ndmeasure._compat._indices((1,))


### PR DESCRIPTION
Refactors out our own vendored copy of `_asarray`. This is a stand-in for the Dask Array function, which is not present in Dask 0.13.0. Pull this out of code we had in `_argwhere`. Also include some tests for different types of data it might be presented with to ensure it properly gets converted to a Dask Array in all cases.