### PR TITLE
Tweak center_of_mass computation

### DIFF
--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -63,7 +63,7 @@ def center_of_mass(input, labels=None, index=None):
     if input.shape != labels.shape:
         raise ValueError("The input and labels arrays must be the same shape.")
 
-    input_ind = _compat._indices(input.shape, chunks=input.chunks)
+    input_i = _compat._indices(input.shape, chunks=input.chunks)
 
     lbl_mtch = operator.eq(
         index[(Ellipsis,) + labels.ndim * (None,)],
@@ -74,7 +74,7 @@ def center_of_mass(input, labels=None, index=None):
 
     input_mtch_ind_wt = (
         input_mtch[index.ndim * (slice(None),) + (None,)] *
-        input_ind[index.ndim * (None,)]
+        input_i[index.ndim * (None,)]
     )
 
     input_mtch = input_mtch.astype(numpy.float64)

--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -70,7 +70,9 @@ def center_of_mass(input, labels=None, index=None):
         labels[index.ndim * (None,)]
     )
 
-    input_mtch = lbl_mtch.astype(input.dtype) * input[index.ndim * (None,)]
+    input_mtch = dask.array.where(
+        lbl_mtch, input[index.ndim * (None,)], input.dtype.type(0)
+    )
 
     input_mtch_ind_wt = (
         input_mtch[index.ndim * (slice(None),) + (None,)] *

--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -70,13 +70,18 @@ def center_of_mass(input, labels=None, index=None):
         labels[index.ndim * (None,)]
     )
 
+    input_i_mtch = dask.array.where(
+        lbl_mtch[index.ndim * (slice(None),) + (None,)],
+        input_i[index.ndim * (None,)],
+        input.dtype.type(0)
+    )
     input_mtch = dask.array.where(
         lbl_mtch, input[index.ndim * (None,)], input.dtype.type(0)
     )
 
     input_mtch_ind_wt = (
         input_mtch[index.ndim * (slice(None),) + (None,)] *
-        input_i[index.ndim * (None,)]
+        input_i_mtch
     )
 
     input_mtch = input_mtch.astype(numpy.float64)

--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -69,9 +69,8 @@ def center_of_mass(input, labels=None, index=None):
         index[(Ellipsis,) + labels.ndim * (None,)],
         labels[index.ndim * (None,)]
     )
-    lbl_mtch = lbl_mtch.astype(input.dtype)
 
-    input_mtch = lbl_mtch * input[index.ndim * (None,)]
+    input_mtch = lbl_mtch.astype(input.dtype) * input[index.ndim * (None,)]
 
     input_mtch_ind_wt = (
         input_mtch[index.ndim * (slice(None),) + (None,)] *


### PR DESCRIPTION
Make some adjustments to clean up the code by doing things like using Dask Array's `where` instead of multiplying masks, which should make it more robust to things like `nan`s. Also mask out the indices based on the labels selected and use this in the center of mass computation. This should make it easier to refactor more code from `center_of_mass`.