### PR TITLE
Add compress

### DIFF
--- a/dask_ndmeasure/_compat.py
+++ b/dask_ndmeasure/_compat.py
@@ -122,22 +122,7 @@ def _argwhere(a):
         ind = dask.array.stack(
             [ind[i].ravel() for i in _pycompat.irange(len(ind))], axis=1
         )
-
-    axis = 0
-    axes = tuple(_pycompat.irange(ind.ndim))
-
-    ind = dask.array.atop(
-        numpy.compress, axes,
-        nz, (axis,),
-        ind, axes,
-        axis=axis,
-        dtype=ind.dtype,
-    )
-    ind._chunks = (
-        ind.chunks[:axis] +
-        (len(ind.chunks[axis]) * (numpy.nan,),) +
-        ind.chunks[axis+1:]
-    )
+    ind = _compress(nz, ind, 0)
 
     return ind
 


### PR DESCRIPTION
Includes a refactored/vendored implementation of NumPy's `compress`. Also uses it in the vendored `argwhere` implementation. This is needed for other functionality that will be included in this library.