### PR TITLE
Simplify label matching function

### DIFF
--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -14,6 +14,9 @@ del get_versions
 
 import numpy
 
+import dask.array
+
+from . import _compat
 from . import _pycompat
 from . import _utils
 
@@ -44,20 +47,28 @@ def center_of_mass(input, labels=None, index=None):
         input, labels, index
     )
 
-    lbl_mtch, input_i_mtch, input_mtch = _utils._get_label_matches(
-        input, labels, index
+    input_i = _compat._indices(
+        input.shape, dtype=numpy.int64, chunks=input.chunks
+    )
+    input_i_wt = input[None] * input_i
+
+    lbl_mtch = _utils._get_label_matches(labels, index)
+
+    input_i_wt_mtch = dask.array.where(
+        lbl_mtch[index.ndim * (slice(None),) + (None,)],
+        input_i_wt[index.ndim * (None,)],
+        input_i_wt.dtype.type(0)
     )
 
-    input_i_mtch_wt = (
-        input_mtch[index.ndim * (slice(None),) + (None,)] *
-        input_i_mtch
+    input_mtch = dask.array.where(
+        lbl_mtch, input[index.ndim * (None,)], input.dtype.type(0)
     )
 
-    input_i_mtch_wt = input_i_mtch_wt.astype(numpy.float64)
+    input_i_wt_mtch = input_i_wt_mtch.astype(numpy.float64)
     input_mtch = input_mtch.astype(numpy.float64)
 
-    com_lbl = input_i_mtch_wt.sum(
-        axis=tuple(_pycompat.irange(1 + index.ndim, input_i_mtch_wt.ndim))
+    com_lbl = input_i_wt_mtch.sum(
+        axis=tuple(_pycompat.irange(1 + index.ndim, input_i_wt_mtch.ndim))
     )
     input_mtch_sum = input_mtch.sum(
         axis=tuple(_pycompat.irange(index.ndim, input_mtch.ndim))

--- a/dask_ndmeasure/_utils.py
+++ b/dask_ndmeasure/_utils.py
@@ -39,24 +39,10 @@ def _norm_input_labels_index(input, labels=None, index=None):
     return (input, labels, index)
 
 
-def _get_label_matches(input, labels, index):
-    input_i = _compat._indices(
-        input.shape, dtype=numpy.int64, chunks=input.chunks
-    )
-
+def _get_label_matches(labels, index):
     lbl_mtch = operator.eq(
         index[(Ellipsis,) + labels.ndim * (None,)],
         labels[index.ndim * (None,)]
     )
 
-    input_i_mtch = dask.array.where(
-        lbl_mtch[index.ndim * (slice(None),) + (None,)],
-        input_i[index.ndim * (None,)],
-        input_i.dtype.type(0)
-    )
-
-    input_mtch = dask.array.where(
-        lbl_mtch, input[index.ndim * (None,)], input.dtype.type(0)
-    )
-
-    return (lbl_mtch, input_i_mtch, input_mtch)
+    return lbl_mtch

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -95,14 +95,8 @@ def test__get_label_matches(shape, chunks, ind):
     )
     input_mtch = lbl_mtch.astype(a.dtype) * a[ind.ndim * (None,)]
 
-    d_lbl_mtch, d_input_i_mtch, d_input_mtch = dask_ndmeasure._utils._get_label_matches(
-        d, d_lbls, ind
-    )
+    d_lbl_mtch = dask_ndmeasure._utils._get_label_matches(d_lbls, ind)
 
     assert issubclass(d_lbl_mtch.dtype.type, np.bool8)
-    assert issubclass(d_input_i_mtch.dtype.type, np.int64)
-    assert issubclass(d_input_mtch.dtype.type, a.dtype.type)
 
     dau.assert_eq(d_lbl_mtch, lbl_mtch)
-    dau.assert_eq(d_input_i_mtch, input_i_mtch)
-    dau.assert_eq(d_input_mtch, input_mtch)


### PR DESCRIPTION
Simplify the internal utility function for finding label matches so that it doesn't find anything extra. Also reinclude some previously refactored code into `center_of_mass` in a simplified form.