### PR TITLE
Move index transpose into center_of_mass

### DIFF
--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -47,6 +47,11 @@ def center_of_mass(input, labels=None, index=None):
         input, labels, index
     )
 
+    # SciPy transposes these for some reason.
+    # So we do the same thing here.
+    # This only matters if index is some array.
+    index = index.T
+
     input_i = _compat._indices(
         input.shape, dtype=numpy.int64, chunks=input.chunks
     )

--- a/dask_ndmeasure/_utils.py
+++ b/dask_ndmeasure/_utils.py
@@ -28,11 +28,6 @@ def _norm_input_labels_index(input, labels=None, index=None):
     labels = _compat._asarray(labels)
     index = _compat._asarray(index)
 
-    # SciPy transposes these for some reason.
-    # So we do the same thing here.
-    # This only matters if index is some array.
-    index = index.T
-
     if input.shape != labels.shape:
         raise ValueError("The input and labels arrays must be the same shape.")
 


### PR DESCRIPTION
The index transposing behavior (i.e. the selected labels) appears to be unique to the `center_of_mass` computation or at least it is not present in `sum`. So this moves that tweak into the `center_of_mass` computation. That way it doesn't contaminate other computations that do not need these. Further it allows the argument normalization function to be reused repeatedly without ill effect.