### PR TITLE
Add sum

### DIFF
--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -81,3 +81,46 @@ def center_of_mass(input, labels=None, index=None):
     com_lbl /= input_mtch_sum[index.ndim * (slice(None),) + (None,)]
 
     return com_lbl
+
+
+def sum(input, labels=None, index=None):
+    """
+    Calculate the sum of the values of the array.
+
+    Parameters
+    ----------
+    input : array_like
+        Values of `input` inside the regions defined by `labels`
+        are summed together.
+    labels : array_like of ints, optional
+        Assign labels to the values of the array. Has to have the same shape as
+        `input`.
+    index : array_like, optional
+        A single label number or a sequence of label numbers of
+        the objects to be measured.
+
+    Returns
+    -------
+    sum : ndarray or scalar
+        An array of the sums of values of `input` inside the regions defined
+        by `labels` with the same shape as `index`. If 'index' is None or scalar,
+        a scalar is returned.
+    """
+
+    input, labels, index = _utils._norm_input_labels_index(
+        input, labels, index
+    )
+
+    lbl_mtch = _utils._get_label_matches(labels, index)
+
+    input_mtch = dask.array.where(
+        lbl_mtch, input[index.ndim * (None,)], input.dtype.type(0)
+    )
+
+    input_mtch = input_mtch.astype(numpy.float64)
+
+    sum_lbl = input_mtch.sum(
+        axis=tuple(_pycompat.irange(index.ndim, input_mtch.ndim))
+    )
+
+    return sum_lbl

--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -52,33 +52,20 @@ def center_of_mass(input, labels=None, index=None):
     # This only matters if index is some array.
     index = index.T
 
+    input_mtch_sum = sum(input, labels, index)
+
     input_i = _compat._indices(
         input.shape, dtype=numpy.int64, chunks=input.chunks
     )
+
     input_i_wt = input[None] * input_i
 
-    lbl_mtch = _utils._get_label_matches(labels, index)
+    input_i_wt_mtch_sum = []
+    for i in _pycompat.irange(len(input_i_wt)):
+        input_i_wt_mtch_sum.append(sum(input_i_wt[i], labels, index))
+    input_i_wt_mtch_sum = dask.array.stack(input_i_wt_mtch_sum, axis=-1)
 
-    input_i_wt_mtch = dask.array.where(
-        lbl_mtch[index.ndim * (slice(None),) + (None,)],
-        input_i_wt[index.ndim * (None,)],
-        input_i_wt.dtype.type(0)
-    )
-
-    input_mtch = dask.array.where(
-        lbl_mtch, input[index.ndim * (None,)], input.dtype.type(0)
-    )
-
-    input_i_wt_mtch = input_i_wt_mtch.astype(numpy.float64)
-    input_mtch = input_mtch.astype(numpy.float64)
-
-    com_lbl = input_i_wt_mtch.sum(
-        axis=tuple(_pycompat.irange(1 + index.ndim, input_i_wt_mtch.ndim))
-    )
-    input_mtch_sum = input_mtch.sum(
-        axis=tuple(_pycompat.irange(index.ndim, input_mtch.ndim))
-    )
-    com_lbl /= input_mtch_sum[index.ndim * (slice(None),) + (None,)]
+    com_lbl = input_i_wt_mtch_sum / input_mtch_sum[..., None]
 
     return com_lbl
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -69,3 +69,40 @@ def test_center_of_mass(shape, chunks, has_lbls, ind):
     d_cm = dask_ndmeasure.center_of_mass(d, lbls, ind)
 
     dask_ndmeasure._test_utils._assert_eq_nan(a_cm, d_cm)
+
+
+@pytest.mark.parametrize(
+    "shape, chunks, has_lbls, ind", [
+        ((15, 16), (4, 5), False, None),
+        ((15, 16), (4, 5), True, None),
+        ((15, 16), (4, 5), True, 0),
+        ((15, 16), (4, 5), True, 1),
+        ((15, 16), (4, 5), True, [1]),
+        ((15, 16), (4, 5), True, [1, 2]),
+        ((15, 16), (4, 5), True, [1, 100]),
+        ((15, 16), (4, 5), True, [[1, 2, 3, 4]]),
+        ((15, 16), (4, 5), True, [[1, 2], [3, 4]]),
+        ((15, 16), (4, 5), True, [[[1], [2], [3], [4]]]),
+    ]
+)
+def test_sum(shape, chunks, has_lbls, ind):
+    a = np.random.random(shape)
+    d = da.from_array(a, chunks=chunks)
+
+    lbls = None
+    d_lbls = None
+
+    if has_lbls:
+        lbls = np.zeros(a.shape, dtype=np.int64)
+        lbls += (
+            (d < 0.5).astype(lbls.dtype) +
+            (d < 0.25).astype(lbls.dtype) +
+            (d < 0.125).astype(lbls.dtype) +
+            (d < 0.0625).astype(lbls.dtype)
+        )
+        d_lbls = da.from_array(lbls, chunks=d.chunks)
+
+    a_cm = np.array(spnd.sum(a, lbls, ind))
+    d_cm = dask_ndmeasure.sum(d, lbls, ind)
+
+    dask_ndmeasure._test_utils._assert_eq_nan(a_cm, d_cm)


### PR DESCRIPTION
Partially addresses issue ( https://github.com/dask-image/dask-ndmeasure/issues/2 ).

Adds a Dask Array function to compute the [sum]( https://docs.scipy.org/doc/scipy-0.19.0/reference/generated/scipy.ndimage.sum.html ). Tries to mimic the SciPy implementation as closely as possible. However it deviates slightly on the output format. Here we provide one array for all of the data; whereas, SciPy has some mixture of arrays and lists in the result.

Also rewrites `center_of_mass` to make use of `sum` for summing values for each label.