### PR TITLE
Add mean

### DIFF
--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -70,6 +70,47 @@ def center_of_mass(input, labels=None, index=None):
     return com_lbl
 
 
+def mean(input, labels=None, index=None):
+    """
+    Calculate the mean of the values of an array at labels.
+
+    Parameters
+    ----------
+    input : array_like
+        Array on which to compute the mean of elements over distinct
+        regions.
+    labels : array_like, optional
+        Array of labels of same shape, or broadcastable to the same shape as
+        `input`. All elements sharing the same label form one region over
+        which the mean of the elements is computed.
+    index : int or sequence of ints, optional
+        Labels of the objects over which the mean is to be computed.
+        Default is None, in which case the mean for all values where label is
+        greater than 0 is calculated.
+
+    Returns
+    -------
+    out : array_like
+        Sequence of same length as `index`, with the mean of the different
+        regions labeled by the labels in `index`.
+    """
+
+    input, labels, index = _utils._norm_input_labels_index(
+        input, labels, index
+    )
+
+    input_sum = sum(input, labels, index)
+    input_norm = sum(
+        dask.array.ones(input.shape, dtype=input.dtype, chunks=input.chunks),
+        labels,
+        index
+    )
+
+    com_lbl = input_sum / input_norm
+
+    return com_lbl
+
+
 def sum(input, labels=None, index=None):
     """
     Calculate the sum of the values of the array.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -85,6 +85,43 @@ def test_center_of_mass(shape, chunks, has_lbls, ind):
         ((15, 16), (4, 5), True, [[[1], [2], [3], [4]]]),
     ]
 )
+def test_mean(shape, chunks, has_lbls, ind):
+    a = np.random.random(shape)
+    d = da.from_array(a, chunks=chunks)
+
+    lbls = None
+    d_lbls = None
+
+    if has_lbls:
+        lbls = np.zeros(a.shape, dtype=np.int64)
+        lbls += (
+            (d < 0.5).astype(lbls.dtype) +
+            (d < 0.25).astype(lbls.dtype) +
+            (d < 0.125).astype(lbls.dtype) +
+            (d < 0.0625).astype(lbls.dtype)
+        )
+        d_lbls = da.from_array(lbls, chunks=d.chunks)
+
+    a_cm = np.array(spnd.mean(a, lbls, ind))
+    d_cm = dask_ndmeasure.mean(d, lbls, ind)
+
+    dask_ndmeasure._test_utils._assert_eq_nan(a_cm, d_cm)
+
+
+@pytest.mark.parametrize(
+    "shape, chunks, has_lbls, ind", [
+        ((15, 16), (4, 5), False, None),
+        ((15, 16), (4, 5), True, None),
+        ((15, 16), (4, 5), True, 0),
+        ((15, 16), (4, 5), True, 1),
+        ((15, 16), (4, 5), True, [1]),
+        ((15, 16), (4, 5), True, [1, 2]),
+        ((15, 16), (4, 5), True, [1, 100]),
+        ((15, 16), (4, 5), True, [[1, 2, 3, 4]]),
+        ((15, 16), (4, 5), True, [[1, 2], [3, 4]]),
+        ((15, 16), (4, 5), True, [[[1], [2], [3], [4]]]),
+    ]
+)
 def test_sum(shape, chunks, has_lbls, ind):
     a = np.random.random(shape)
     d = da.from_array(a, chunks=chunks)


### PR DESCRIPTION
Partially addresses issue ( https://github.com/dask-image/dask-ndmeasure/issues/2 ).

Adds a Dask Array function to compute the [mean]( https://docs.scipy.org/doc/scipy-0.19.0/reference/generated/scipy.ndimage.mean.html ). Tries to mimic the SciPy implementation as closely as possible. However it deviates slightly on the output format. Here we provide one array for all of the data; whereas, SciPy has some mixture of arrays and lists in the result.