### PR TITLE
Add variance

### DIFF
--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -152,3 +152,38 @@ def sum(input, labels=None, index=None):
     )
 
     return sum_lbl
+
+
+def variance(input, labels=None, index=None):
+    """
+    Calculate the variance of the values of an n-D image array, optionally at
+    specified sub-regions.
+
+    Parameters
+    ----------
+    input : array_like
+        Nd-image data to process.
+    labels : array_like, optional
+        Labels defining sub-regions in `input`.
+        If not None, must be same shape as `input`.
+    index : int or sequence of ints, optional
+        `labels` to include in output.  If None (default), all values where
+        `labels` is non-zero are used.
+
+    Returns
+    -------
+    variance : array-like
+        Values of variance, for each sub-region if `labels` and `index` are
+        specified.
+    """
+
+    input, labels, index = _utils._norm_input_labels_index(
+        input, labels, index
+    )
+
+    input_2_mean = mean(dask.array.square(input), labels, index)
+    input_mean_2 = dask.array.square(mean(input, labels, index))
+
+    var_lbl = input_2_mean - input_mean_2
+
+    return var_lbl

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -143,3 +143,40 @@ def test_sum(shape, chunks, has_lbls, ind):
     d_cm = dask_ndmeasure.sum(d, lbls, ind)
 
     dask_ndmeasure._test_utils._assert_eq_nan(a_cm, d_cm)
+
+
+@pytest.mark.parametrize(
+    "shape, chunks, has_lbls, ind", [
+        ((15, 16), (4, 5), False, None),
+        ((15, 16), (4, 5), True, None),
+        ((15, 16), (4, 5), True, 0),
+        ((15, 16), (4, 5), True, 1),
+        ((15, 16), (4, 5), True, [1]),
+        ((15, 16), (4, 5), True, [1, 2]),
+        ((15, 16), (4, 5), True, [1, 100]),
+        ((15, 16), (4, 5), True, [[1, 2, 3, 4]]),
+        ((15, 16), (4, 5), True, [[1, 2], [3, 4]]),
+        ((15, 16), (4, 5), True, [[[1], [2], [3], [4]]]),
+    ]
+)
+def test_variance(shape, chunks, has_lbls, ind):
+    a = np.random.random(shape)
+    d = da.from_array(a, chunks=chunks)
+
+    lbls = None
+    d_lbls = None
+
+    if has_lbls:
+        lbls = np.zeros(a.shape, dtype=np.int64)
+        lbls += (
+            (d < 0.5).astype(lbls.dtype) +
+            (d < 0.25).astype(lbls.dtype) +
+            (d < 0.125).astype(lbls.dtype) +
+            (d < 0.0625).astype(lbls.dtype)
+        )
+        d_lbls = da.from_array(lbls, chunks=d.chunks)
+
+    a_cm = np.array(spnd.variance(a, lbls, ind))
+    d_cm = dask_ndmeasure.variance(d, lbls, ind)
+
+    dask_ndmeasure._test_utils._assert_eq_nan(a_cm, d_cm)


### PR DESCRIPTION
Partially addresses issue ( https://github.com/dask-image/dask-ndmeasure/issues/2 ).

Adds a Dask Array function to compute the [variance]( https://docs.scipy.org/doc/scipy-0.19.0/reference/generated/scipy.ndimage.variance.html ). Tries to mimic the SciPy implementation as closely as possible. However it deviates slightly on the output format. Here we provide one array for all of the data; whereas, SciPy has some mixture of arrays and lists in the result.