### PR TITLE
Add standard_deviation

### DIFF
--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -111,6 +111,38 @@ def mean(input, labels=None, index=None):
     return com_lbl
 
 
+def standard_deviation(input, labels=None, index=None):
+    """
+    Calculate the standard deviation of the values of an n-D image array,
+    optionally at specified sub-regions.
+
+    Parameters
+    ----------
+    input : array_like
+        Nd-image data to process.
+    labels : array_like, optional
+        Labels to identify sub-regions in `input`.
+        If not None, must be same shape as `input`.
+    index : int or sequence of ints, optional
+        `labels` to include in output.  If None (default), all values where
+        `labels` is non-zero are used.
+
+    Returns
+    -------
+    standard_deviation : float or ndarray
+        Values of standard deviation, for each sub-region if `labels` and
+        `index` are specified.
+    """
+
+    input, labels, index = _utils._norm_input_labels_index(
+        input, labels, index
+    )
+
+    std_lbl = dask.array.sqrt(variance(input, labels, index))
+
+    return std_lbl
+
+
 def sum(input, labels=None, index=None):
     """
     Calculate the sum of the values of the array.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -122,6 +122,43 @@ def test_mean(shape, chunks, has_lbls, ind):
         ((15, 16), (4, 5), True, [[[1], [2], [3], [4]]]),
     ]
 )
+def test_standard_deviation(shape, chunks, has_lbls, ind):
+    a = np.random.random(shape)
+    d = da.from_array(a, chunks=chunks)
+
+    lbls = None
+    d_lbls = None
+
+    if has_lbls:
+        lbls = np.zeros(a.shape, dtype=np.int64)
+        lbls += (
+            (d < 0.5).astype(lbls.dtype) +
+            (d < 0.25).astype(lbls.dtype) +
+            (d < 0.125).astype(lbls.dtype) +
+            (d < 0.0625).astype(lbls.dtype)
+        )
+        d_lbls = da.from_array(lbls, chunks=d.chunks)
+
+    a_cm = np.array(spnd.standard_deviation(a, lbls, ind))
+    d_cm = dask_ndmeasure.standard_deviation(d, lbls, ind)
+
+    dask_ndmeasure._test_utils._assert_eq_nan(a_cm, d_cm)
+
+
+@pytest.mark.parametrize(
+    "shape, chunks, has_lbls, ind", [
+        ((15, 16), (4, 5), False, None),
+        ((15, 16), (4, 5), True, None),
+        ((15, 16), (4, 5), True, 0),
+        ((15, 16), (4, 5), True, 1),
+        ((15, 16), (4, 5), True, [1]),
+        ((15, 16), (4, 5), True, [1, 2]),
+        ((15, 16), (4, 5), True, [1, 100]),
+        ((15, 16), (4, 5), True, [[1, 2, 3, 4]]),
+        ((15, 16), (4, 5), True, [[1, 2], [3, 4]]),
+        ((15, 16), (4, 5), True, [[[1], [2], [3], [4]]]),
+    ]
+)
 def test_sum(shape, chunks, has_lbls, ind):
     a = np.random.random(shape)
     d = da.from_array(a, chunks=chunks)


### PR DESCRIPTION
Partially addresses issue ( https://github.com/dask-image/dask-ndmeasure/issues/2 ).

Adds a Dask Array function to compute the [standard_deviation]( https://docs.scipy.org/doc/scipy-0.19.0/reference/generated/scipy.ndimage.standard_deviation.html ). Tries to mimic the SciPy implementation as closely as possible. However it deviates slightly on the output format. Here we provide one array for all of the data; whereas, SciPy has some mixture of arrays and lists in the result.