### PR TITLE
Consolidate and parameterize tests

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -35,6 +35,11 @@ def test_center_of_mass_err():
 
 
 @pytest.mark.parametrize(
+    "funcname", [
+        "center_of_mass",
+    ]
+)
+@pytest.mark.parametrize(
     "shape, chunks, has_lbls, ind", [
         ((15, 16), (4, 5), False, None),
         ((15, 16), (4, 5), True, None),
@@ -48,7 +53,10 @@ def test_center_of_mass_err():
         ((15, 16), (4, 5), True, [[[1], [2], [3], [4]]]),
     ]
 )
-def test_center_of_mass(shape, chunks, has_lbls, ind):
+def test_center_of_mass(funcname, shape, chunks, has_lbls, ind):
+    sp_func = getattr(spnd, funcname)
+    da_func = getattr(dask_ndmeasure, funcname)
+
     a = np.random.random(shape)
     d = da.from_array(a, chunks=chunks)
 
@@ -65,8 +73,8 @@ def test_center_of_mass(shape, chunks, has_lbls, ind):
         )
         d_lbls = da.from_array(lbls, chunks=d.chunks)
 
-    a_cm = np.array(spnd.center_of_mass(a, lbls, ind))
-    d_cm = dask_ndmeasure.center_of_mass(d, lbls, ind)
+    a_cm = np.array(sp_func(a, lbls, ind))
+    d_cm = da_func(d, lbls, ind)
 
     dask_ndmeasure._test_utils._assert_eq_nan(a_cm, d_cm)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -37,6 +37,10 @@ def test_center_of_mass_err():
 @pytest.mark.parametrize(
     "funcname", [
         "center_of_mass",
+        "mean",
+        "standard_deviation",
+        "sum",
+        "variance",
     ]
 )
 @pytest.mark.parametrize(
@@ -53,7 +57,7 @@ def test_center_of_mass_err():
         ((15, 16), (4, 5), True, [[[1], [2], [3], [4]]]),
     ]
 )
-def test_center_of_mass(funcname, shape, chunks, has_lbls, ind):
+def test_measure_props(funcname, shape, chunks, has_lbls, ind):
     sp_func = getattr(spnd, funcname)
     da_func = getattr(dask_ndmeasure, funcname)
 
@@ -75,153 +79,5 @@ def test_center_of_mass(funcname, shape, chunks, has_lbls, ind):
 
     a_cm = np.array(sp_func(a, lbls, ind))
     d_cm = da_func(d, lbls, ind)
-
-    dask_ndmeasure._test_utils._assert_eq_nan(a_cm, d_cm)
-
-
-@pytest.mark.parametrize(
-    "shape, chunks, has_lbls, ind", [
-        ((15, 16), (4, 5), False, None),
-        ((15, 16), (4, 5), True, None),
-        ((15, 16), (4, 5), True, 0),
-        ((15, 16), (4, 5), True, 1),
-        ((15, 16), (4, 5), True, [1]),
-        ((15, 16), (4, 5), True, [1, 2]),
-        ((15, 16), (4, 5), True, [1, 100]),
-        ((15, 16), (4, 5), True, [[1, 2, 3, 4]]),
-        ((15, 16), (4, 5), True, [[1, 2], [3, 4]]),
-        ((15, 16), (4, 5), True, [[[1], [2], [3], [4]]]),
-    ]
-)
-def test_mean(shape, chunks, has_lbls, ind):
-    a = np.random.random(shape)
-    d = da.from_array(a, chunks=chunks)
-
-    lbls = None
-    d_lbls = None
-
-    if has_lbls:
-        lbls = np.zeros(a.shape, dtype=np.int64)
-        lbls += (
-            (d < 0.5).astype(lbls.dtype) +
-            (d < 0.25).astype(lbls.dtype) +
-            (d < 0.125).astype(lbls.dtype) +
-            (d < 0.0625).astype(lbls.dtype)
-        )
-        d_lbls = da.from_array(lbls, chunks=d.chunks)
-
-    a_cm = np.array(spnd.mean(a, lbls, ind))
-    d_cm = dask_ndmeasure.mean(d, lbls, ind)
-
-    dask_ndmeasure._test_utils._assert_eq_nan(a_cm, d_cm)
-
-
-@pytest.mark.parametrize(
-    "shape, chunks, has_lbls, ind", [
-        ((15, 16), (4, 5), False, None),
-        ((15, 16), (4, 5), True, None),
-        ((15, 16), (4, 5), True, 0),
-        ((15, 16), (4, 5), True, 1),
-        ((15, 16), (4, 5), True, [1]),
-        ((15, 16), (4, 5), True, [1, 2]),
-        ((15, 16), (4, 5), True, [1, 100]),
-        ((15, 16), (4, 5), True, [[1, 2, 3, 4]]),
-        ((15, 16), (4, 5), True, [[1, 2], [3, 4]]),
-        ((15, 16), (4, 5), True, [[[1], [2], [3], [4]]]),
-    ]
-)
-def test_standard_deviation(shape, chunks, has_lbls, ind):
-    a = np.random.random(shape)
-    d = da.from_array(a, chunks=chunks)
-
-    lbls = None
-    d_lbls = None
-
-    if has_lbls:
-        lbls = np.zeros(a.shape, dtype=np.int64)
-        lbls += (
-            (d < 0.5).astype(lbls.dtype) +
-            (d < 0.25).astype(lbls.dtype) +
-            (d < 0.125).astype(lbls.dtype) +
-            (d < 0.0625).astype(lbls.dtype)
-        )
-        d_lbls = da.from_array(lbls, chunks=d.chunks)
-
-    a_cm = np.array(spnd.standard_deviation(a, lbls, ind))
-    d_cm = dask_ndmeasure.standard_deviation(d, lbls, ind)
-
-    dask_ndmeasure._test_utils._assert_eq_nan(a_cm, d_cm)
-
-
-@pytest.mark.parametrize(
-    "shape, chunks, has_lbls, ind", [
-        ((15, 16), (4, 5), False, None),
-        ((15, 16), (4, 5), True, None),
-        ((15, 16), (4, 5), True, 0),
-        ((15, 16), (4, 5), True, 1),
-        ((15, 16), (4, 5), True, [1]),
-        ((15, 16), (4, 5), True, [1, 2]),
-        ((15, 16), (4, 5), True, [1, 100]),
-        ((15, 16), (4, 5), True, [[1, 2, 3, 4]]),
-        ((15, 16), (4, 5), True, [[1, 2], [3, 4]]),
-        ((15, 16), (4, 5), True, [[[1], [2], [3], [4]]]),
-    ]
-)
-def test_sum(shape, chunks, has_lbls, ind):
-    a = np.random.random(shape)
-    d = da.from_array(a, chunks=chunks)
-
-    lbls = None
-    d_lbls = None
-
-    if has_lbls:
-        lbls = np.zeros(a.shape, dtype=np.int64)
-        lbls += (
-            (d < 0.5).astype(lbls.dtype) +
-            (d < 0.25).astype(lbls.dtype) +
-            (d < 0.125).astype(lbls.dtype) +
-            (d < 0.0625).astype(lbls.dtype)
-        )
-        d_lbls = da.from_array(lbls, chunks=d.chunks)
-
-    a_cm = np.array(spnd.sum(a, lbls, ind))
-    d_cm = dask_ndmeasure.sum(d, lbls, ind)
-
-    dask_ndmeasure._test_utils._assert_eq_nan(a_cm, d_cm)
-
-
-@pytest.mark.parametrize(
-    "shape, chunks, has_lbls, ind", [
-        ((15, 16), (4, 5), False, None),
-        ((15, 16), (4, 5), True, None),
-        ((15, 16), (4, 5), True, 0),
-        ((15, 16), (4, 5), True, 1),
-        ((15, 16), (4, 5), True, [1]),
-        ((15, 16), (4, 5), True, [1, 2]),
-        ((15, 16), (4, 5), True, [1, 100]),
-        ((15, 16), (4, 5), True, [[1, 2, 3, 4]]),
-        ((15, 16), (4, 5), True, [[1, 2], [3, 4]]),
-        ((15, 16), (4, 5), True, [[[1], [2], [3], [4]]]),
-    ]
-)
-def test_variance(shape, chunks, has_lbls, ind):
-    a = np.random.random(shape)
-    d = da.from_array(a, chunks=chunks)
-
-    lbls = None
-    d_lbls = None
-
-    if has_lbls:
-        lbls = np.zeros(a.shape, dtype=np.int64)
-        lbls += (
-            (d < 0.5).astype(lbls.dtype) +
-            (d < 0.25).astype(lbls.dtype) +
-            (d < 0.125).astype(lbls.dtype) +
-            (d < 0.0625).astype(lbls.dtype)
-        )
-        d_lbls = da.from_array(lbls, chunks=d.chunks)
-
-    a_cm = np.array(spnd.variance(a, lbls, ind))
-    d_cm = dask_ndmeasure.variance(d, lbls, ind)
 
     dask_ndmeasure._test_utils._assert_eq_nan(a_cm, d_cm)


### PR DESCRIPTION
Parameterize one of the tests to handle various different functions. This allows for a lot of duplicated code to be cleaned up.