### PR TITLE
Fixes for test_measure_props

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -89,6 +89,6 @@ def test_measure_props(funcname, shape, chunks, has_lbls, ind):
         d_lbls = da.from_array(lbls, chunks=d.chunks)
 
     a_cm = np.array(sp_func(a, lbls, ind))
-    d_cm = da_func(d, lbls, ind)
+    d_cm = da_func(d, d_lbls, ind)
 
     dask_ndmeasure._test_utils._assert_eq_nan(a_cm, d_cm)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -88,7 +88,7 @@ def test_measure_props(funcname, shape, chunks, has_lbls, ind):
         )
         d_lbls = da.from_array(lbls, chunks=d.chunks)
 
-    a_cm = np.array(sp_func(a, lbls, ind))
-    d_cm = da_func(d, d_lbls, ind)
+    a_r = np.array(sp_func(a, lbls, ind))
+    d_r = da_func(d, d_lbls, ind)
 
-    dask_ndmeasure._test_utils._assert_eq_nan(a_cm, d_cm)
+    dask_ndmeasure._test_utils._assert_eq_nan(a_r, d_r)


### PR DESCRIPTION
* Use the Dask Array of label images in Dask computation.
* Rename variables to make the generality here explicit.