### PR TITLE
Add labeled_comprehension

### DIFF
--- a/dask_ndmeasure/_utils.py
+++ b/dask_ndmeasure/_utils.py
@@ -66,3 +66,24 @@ def _ravel_shape_indices(dimensions, dtype=int, chunks=None):
     indices = dask.array.stack(indices).sum(axis=0)
 
     return indices
+
+
+def _labeled_comprehension_func(func,
+                                out_dtype,
+                                default,
+                                compute,
+                                *args,
+                                **kwargs):
+    """
+    Wrapped labeled comprehension function
+
+    Included in the module for pickling purposes. Also handle cases where
+    computation should not occur.
+    """
+
+    out_dtype = numpy.dtype(out_dtype)
+
+    if compute:
+        return out_dtype.type(func(*args, **kwargs))
+    else:
+        return out_dtype.type(default)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -143,4 +143,6 @@ def test_labeled_comprehension(shape, chunks, ind, default, pass_positions):
         d, d_lbls, ind, func, np.float64, default, pass_positions
     )
 
-    dask_ndmeasure._test_utils._assert_eq_nan(a_cm, d_cm)
+    assert a_cm.dtype == d_cm.dtype
+    assert a_cm.shape == d_cm.shape
+    assert np.allclose(np.array(a_cm), np.array(d_cm), equal_nan=True)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -92,3 +92,55 @@ def test_measure_props(funcname, shape, chunks, has_lbls, ind):
     d_r = da_func(d, d_lbls, ind)
 
     dask_ndmeasure._test_utils._assert_eq_nan(a_r, d_r)
+
+
+@pytest.mark.parametrize(
+    "shape, chunks, ind", [
+        ((15, 16), (4, 5), None),
+        ((15, 16), (4, 5), 0),
+        ((15, 16), (4, 5), 1),
+        ((15, 16), (4, 5), [1]),
+        ((15, 16), (4, 5), [1, 2]),
+        ((15, 16), (4, 5), [1, 100]),
+    ]
+)
+@pytest.mark.parametrize(
+    "default", [
+        None,
+        0,
+        1.5,
+    ]
+)
+@pytest.mark.parametrize(
+    "pass_positions", [
+        False,
+        True,
+    ]
+)
+def test_labeled_comprehension(shape, chunks, ind, default, pass_positions):
+    a = np.random.random(shape)
+    d = da.from_array(a, chunks=chunks)
+
+    lbls = np.zeros(a.shape, dtype=np.int64)
+    lbls += (
+        (a < 0.5).astype(lbls.dtype) +
+        (a < 0.25).astype(lbls.dtype) +
+        (a < 0.125).astype(lbls.dtype) +
+        (a < 0.0625).astype(lbls.dtype)
+    )
+    d_lbls = da.from_array(lbls, chunks=d.chunks)
+
+    def func(val, pos=None):
+        if pos is None:
+            pos = 0 * val + 1
+
+        return (val * pos).sum() / (1 + val.max() * pos.max())
+
+    a_cm = spnd.labeled_comprehension(
+        a, lbls, ind, func, np.float64, default, pass_positions
+    )
+    d_cm = dask_ndmeasure.labeled_comprehension(
+        d, d_lbls, ind, func, np.float64, default, pass_positions
+    )
+
+    dask_ndmeasure._test_utils._assert_eq_nan(a_cm, d_cm)


### PR DESCRIPTION
Partially addresses issue ( https://github.com/dask-image/dask-ndmeasure/issues/2 ).

Adds a Dask Array function to compute the [labeled_comprehension]( https://docs.scipy.org/doc/scipy-0.19.0/reference/generated/scipy.ndimage.labeled_comprehension.html ). Tries to mimic the SciPy implementation as closely as possible.