### PR TITLE
Test fixes for dask 0.15.1

### DIFF
--- a/tests/test__compat.py
+++ b/tests/test__compat.py
@@ -170,7 +170,7 @@ def test_compress_err_axis(axis):
 
     m = (x < 5)
     d_m = da.from_array(m, chunks=chunks)
-    if axis is None:
+    if axis is None or not np.prod(shape):
         m = m.flatten()
         d_m = d_m.flatten()
     else:
@@ -221,7 +221,7 @@ def test_compress(shape, chunks, axis):
 
     m = (x < 5)
     d_m = da.from_array(m, chunks=chunks)
-    if axis is None:
+    if axis is None or not np.prod(shape):
         m = m.flatten()
         d_m = d_m.flatten()
     else:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -81,10 +81,10 @@ def test_measure_props(funcname, shape, chunks, has_lbls, ind):
     if has_lbls:
         lbls = np.zeros(a.shape, dtype=np.int64)
         lbls += (
-            (d < 0.5).astype(lbls.dtype) +
-            (d < 0.25).astype(lbls.dtype) +
-            (d < 0.125).astype(lbls.dtype) +
-            (d < 0.0625).astype(lbls.dtype)
+            (a < 0.5).astype(lbls.dtype) +
+            (a < 0.25).astype(lbls.dtype) +
+            (a < 0.125).astype(lbls.dtype) +
+            (a < 0.0625).astype(lbls.dtype)
         )
         d_lbls = da.from_array(lbls, chunks=d.chunks)
 


### PR DESCRIPTION
Makes some fixes for dask 0.15.1 that are noted below.

* Fixes an issue caused by generating the test data for the label array.
* Simplifies and fixes handling of trivial arrays (having a length 0 dimension).