### PR TITLE
Rework core tests without `assert_eq` comparisons

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -10,7 +10,6 @@ import numpy as np
 import scipy.ndimage as spnd
 
 import dask.array as da
-import dask.array.utils as dau
 
 import dask_ndmeasure
 import dask_ndmeasure._test_utils
@@ -91,7 +90,9 @@ def test_measure_props(funcname, shape, chunks, has_lbls, ind):
     a_r = np.array(sp_func(a, lbls, ind))
     d_r = da_func(d, d_lbls, ind)
 
-    dask_ndmeasure._test_utils._assert_eq_nan(a_r, d_r)
+    assert a_r.dtype == d_r.dtype
+    assert a_r.shape == d_r.shape
+    assert np.allclose(np.array(a_r), np.array(d_r), equal_nan=True)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
As newer versions of Dask appear to have issues using `assert_eq` on `delayed`-based Dask Arrays, `assert_eq` cannot be used anywhere `delayed` might be used. Since `labeled_comprehension` will be needed to implement some new functionality and it makes use of `delayed`, `assert_eq` cannot be used in `test_core`. So we replace all usages of `assert_eq` and related functions with our own direct comparisons.