### PR TITLE
Use nan trick to speed-up minimum and maximum

### DIFF
--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -411,9 +411,21 @@ def minimum(input, labels=None, index=None):
         input, labels, index
     )
 
-    min_lbl = labeled_comprehension(
-        input, labels, index, numpy.min, input.dtype, 0
+    lbl_mtch = _utils._get_label_matches(labels, index)
+
+    lbl_mtch_any = lbl_mtch.any(
+        axis=tuple(_pycompat.irange(index.ndim, lbl_mtch.ndim))
     )
+
+    input_mtch = dask.array.where(
+        lbl_mtch, input[index.ndim * (None,)], numpy.nan
+    )
+
+    nanmin_lbl = dask.array.nanmin(
+        input_mtch, axis=tuple(_pycompat.irange(index.ndim, input_mtch.ndim))
+    )
+
+    min_lbl = dask.array.where(lbl_mtch_any, nanmin_lbl, 0).astype(input.dtype)
 
     return min_lbl
 

--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -238,9 +238,21 @@ def maximum(input, labels=None, index=None):
         input, labels, index
     )
 
-    max_lbl = labeled_comprehension(
-        input, labels, index, numpy.max, input.dtype, 0
+    lbl_mtch = _utils._get_label_matches(labels, index)
+
+    lbl_mtch_any = lbl_mtch.any(
+        axis=tuple(_pycompat.irange(index.ndim, lbl_mtch.ndim))
     )
+
+    input_mtch = dask.array.where(
+        lbl_mtch, input[index.ndim * (None,)], numpy.nan
+    )
+
+    nanmax_lbl = dask.array.nanmax(
+        input_mtch, axis=tuple(_pycompat.irange(index.ndim, input_mtch.ndim))
+    )
+
+    max_lbl = dask.array.where(lbl_mtch_any, nanmax_lbl, 0).astype(input.dtype)
 
     return max_lbl
 


### PR DESCRIPTION
This basically is a clever trick to avoid using `labeled_comprehension` in the computation of `minimum` and `maximum`. It works by replacing the values to ignore with `nan`. This way `nanmin` and `nanmax` can be run and all of the `nan` values will be ignored (unless there are only `nan` values). If there were no matches for a label, those values are replaced with `0` using `where`. The result is then cast back to its original type. This change up results in a notable speedup (~2x faster) by avoiding `labeled_comprehension` (likely `delayed` in particular).