### PR TITLE
Rewrite sum with labeled_comprehension

### DIFF
--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -612,16 +612,8 @@ def sum(input, labels=None, index=None):
         input, labels, index
     )
 
-    lbl_mtch = _utils._get_label_matches(labels, index)
-
-    input_mtch = dask.array.where(
-        lbl_mtch, input[index.ndim * (None,)], input.dtype.type(0)
-    )
-
-    input_mtch = input_mtch.astype(numpy.float64)
-
-    sum_lbl = input_mtch.sum(
-        axis=tuple(_pycompat.irange(index.ndim, input_mtch.ndim))
+    sum_lbl = labeled_comprehension(
+        input, labels, index, numpy.sum, numpy.float64, numpy.float64(0)
     )
 
     return sum_lbl


### PR DESCRIPTION
Rewrites our `sum` implementation to make use of `labeled_comprehension` for performing the computation. This should provide some more coverage of `labeled_comprehension` and give us more confidence in using it in other cases. Also as masks are used to select out the data of interest, we are able to avoid performing computations on values that are not of interest (i.e. not in the mask). As such we are able to achieve a not insignificant speedup (~40%).