### PR TITLE
Add maximum_position

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -19,6 +19,7 @@ import dask_ndmeasure._test_utils
     "funcname", [
         "center_of_mass",
         "maximum",
+        "maximum_position",
         "mean",
         "minimum",
         "standard_deviation",
@@ -50,6 +51,7 @@ def test_measure_props_err(funcname):
     "funcname", [
         "center_of_mass",
         "maximum",
+        "maximum_position",
         "mean",
         "minimum",
         "standard_deviation",


### PR DESCRIPTION
Partially addresses issue ( https://github.com/dask-image/dask-ndmeasure/issues/2 ).

Adds a Dask Array function to compute the [maximum_position]( https://docs.scipy.org/doc/scipy-0.19.0/reference/generated/scipy.ndimage.maximum_position.html ). Tries to mimic the SciPy implementation as closely as possible. However it deviates slightly on the output format. Here we provide one array for all of the data; whereas, SciPy has some mixture of arrays and lists in the result.