### PR TITLE
Add extrema

### DIFF
--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -73,6 +73,51 @@ def center_of_mass(input, labels=None, index=None):
     return com_lbl
 
 
+def extrema(input, labels=None, index=None):
+    """
+    Calculate the minimums and maximums of the values of an array
+    at labels, along with their positions.
+
+    Parameters
+    ----------
+    input : ndarray
+        Nd-image data to process.
+    labels : ndarray, optional
+        Labels of features in input.
+        If not None, must be same shape as `input`.
+    index : int or sequence of ints, optional
+        Labels to include in output.  If None (default), all values where
+        non-zero `labels` are used.
+
+    Returns
+    -------
+    minimums, maximums : int or ndarray
+        Values of minimums and maximums in each feature.
+    min_positions, max_positions : tuple or list of tuples
+        Each tuple gives the n-D coordinates of the corresponding minimum
+        or maximum.
+    """
+
+    input, labels, index = _utils._norm_input_labels_index(
+        input, labels, index
+    )
+
+    min_lbl = minimum(
+        input, labels, index
+    )
+    max_lbl = maximum(
+        input, labels, index
+    )
+    min_pos_lbl = minimum_position(
+        input, labels, index
+    )
+    max_pos_lbl = maximum_position(
+        input, labels, index
+    )
+
+    return min_lbl, max_lbl, min_pos_lbl, max_pos_lbl
+
+
 def labeled_comprehension(input,
                           labels,
                           index,


### PR DESCRIPTION
Partially addresses issue ( https://github.com/dask-image/dask-ndmeasure/issues/2 ).

Adds a Dask Array function to compute the [extrema]( https://docs.scipy.org/doc/scipy-0.19.0/reference/generated/scipy.ndimage.extrema.html ). Tries to mimic the SciPy implementation as closely as possible. However it deviates slightly on the output format. Here we provide one array for all of the data; whereas, SciPy has some mixture of arrays and lists in the result.