### PR TITLE
Stylistic fixes for labeled_comprehension

### DIFF
--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -175,7 +175,7 @@ def labeled_comprehension(input,
         axis=tuple(_pycompat.irange(index.ndim, lbl_mtch.ndim))
     )
 
-    indices = _utils._ravel_shape_indices(
+    positions = _utils._ravel_shape_indices(
         input.shape, dtype=numpy.int64, chunks=input.chunks
     )
 
@@ -183,7 +183,7 @@ def labeled_comprehension(input,
     for i in itertools.product(*[_pycompat.irange(j) for j in index.shape]):
         args = (input[lbl_mtch[i]],)
         if pass_positions:
-            args += (indices[lbl_mtch[i]],)
+            args += (positions[lbl_mtch[i]],)
 
         result[i] = dask.delayed(_utils._labeled_comprehension_func)(
             func, out_dtype, default, lbl_mtch_any[i], *args

--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -169,14 +169,14 @@ def labeled_comprehension(input,
     default = numpy.array(default, dtype=out_dtype)[()]
     pass_positions = bool(pass_positions)
 
-    indices = _utils._ravel_shape_indices(
-        input.shape, dtype=numpy.int64, chunks=input.chunks
-    )
-
     lbl_mtch = _utils._get_label_matches(labels, index)
 
     lbl_mtch_any = lbl_mtch.any(
         axis=tuple(_pycompat.irange(index.ndim, lbl_mtch.ndim))
+    )
+
+    indices = _utils._ravel_shape_indices(
+        input.shape, dtype=numpy.int64, chunks=input.chunks
     )
 
     result = numpy.empty(index.shape, dtype=object)

--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -191,14 +191,10 @@ def labeled_comprehension(input,
         result[i] = dask.array.from_delayed(result[i], tuple(), out_dtype)
 
     for i in _pycompat.irange(result.ndim - 1, -1, -1):
-        p = itertools.product(*[
-            _pycompat.irange(e) for e in index.shape[:i]
-        ])
+        p = itertools.product(*[_pycompat.irange(e) for e in index.shape[:i]])
         result2 = result[..., 0]
         for j in p:
-            result2[j] = dask.array.stack(
-                result[j].tolist(), axis=0
-            )
+            result2[j] = dask.array.stack(result[j].tolist(), axis=0)
         result = result2
     result = result[()]
 


### PR DESCRIPTION
Some minor stylistic improvements to `labeled_comprehension` like renaming variables, unwrapping lines that can fit on one line, etc.