### PR TITLE
Optimize labeled_comprehension

### DIFF
--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -181,13 +181,8 @@ def labeled_comprehension(input,
     result = numpy.empty(index.shape, dtype=object)
     for i in itertools.product(*[_pycompat.irange(j) for j in index.shape]):
         args_lbl_mtch_i = tuple(e[lbl_mtch[i]] for e in args)
-
-        result[i] = dask.array.from_delayed(
-            dask.delayed(_utils._labeled_comprehension_func)(
-                func, out_dtype, default, *args_lbl_mtch_i
-            ),
-            tuple(),
-            out_dtype
+        result[i] = _utils._labeled_comprehension_func(
+            func, out_dtype, default, *args_lbl_mtch_i
         )
 
     for i in _pycompat.irange(result.ndim - 1, -1, -1):

--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -171,10 +171,6 @@ def labeled_comprehension(input,
 
     lbl_mtch = _utils._get_label_matches(labels, index)
 
-    lbl_mtch_any = lbl_mtch.any(
-        axis=tuple(_pycompat.irange(index.ndim, lbl_mtch.ndim))
-    )
-
     positions = _utils._ravel_shape_indices(
         input.shape, dtype=numpy.int64, chunks=input.chunks
     )
@@ -186,7 +182,7 @@ def labeled_comprehension(input,
             args += (positions[lbl_mtch[i]],)
 
         result[i] = dask.delayed(_utils._labeled_comprehension_func)(
-            func, out_dtype, default, lbl_mtch_any[i], *args
+            func, out_dtype, default, *args
         )
         result[i] = dask.array.from_delayed(result[i], tuple(), out_dtype)
 

--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -182,10 +182,13 @@ def labeled_comprehension(input,
     for i in itertools.product(*[_pycompat.irange(j) for j in index.shape]):
         args_lbl_mtch_i = tuple(e[lbl_mtch[i]] for e in args)
 
-        result[i] = dask.delayed(_utils._labeled_comprehension_func)(
-            func, out_dtype, default, *args_lbl_mtch_i
+        result[i] = dask.array.from_delayed(
+            dask.delayed(_utils._labeled_comprehension_func)(
+                func, out_dtype, default, *args_lbl_mtch_i
+            ),
+            tuple(),
+            out_dtype
         )
-        result[i] = dask.array.from_delayed(result[i], tuple(), out_dtype)
 
     for i in _pycompat.irange(result.ndim - 1, -1, -1):
         p = itertools.product(*[_pycompat.irange(e) for e in index.shape[:i]])

--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -171,18 +171,19 @@ def labeled_comprehension(input,
 
     lbl_mtch = _utils._get_label_matches(labels, index)
 
-    positions = _utils._ravel_shape_indices(
-        input.shape, dtype=numpy.int64, chunks=input.chunks
-    )
+    args = (input,)
+    if pass_positions:
+        positions = _utils._ravel_shape_indices(
+            input.shape, dtype=numpy.int64, chunks=input.chunks
+        )
+        args = (input, positions)
 
     result = numpy.empty(index.shape, dtype=object)
     for i in itertools.product(*[_pycompat.irange(j) for j in index.shape]):
-        args = (input[lbl_mtch[i]],)
-        if pass_positions:
-            args += (positions[lbl_mtch[i]],)
+        args_lbl_mtch_i = tuple(e[lbl_mtch[i]] for e in args)
 
         result[i] = dask.delayed(_utils._labeled_comprehension_func)(
-            func, out_dtype, default, *args
+            func, out_dtype, default, *args_lbl_mtch_i
         )
         result[i] = dask.array.from_delayed(result[i], tuple(), out_dtype)
 

--- a/dask_ndmeasure/_utils.py
+++ b/dask_ndmeasure/_utils.py
@@ -71,7 +71,6 @@ def _ravel_shape_indices(dimensions, dtype=int, chunks=None):
 def _labeled_comprehension_func(func,
                                 out_dtype,
                                 default,
-                                compute,
                                 a,
                                 positions=None):
     """
@@ -83,7 +82,7 @@ def _labeled_comprehension_func(func,
 
     out_dtype = numpy.dtype(out_dtype)
 
-    if compute:
+    if a.size:
         if positions is None:
             return out_dtype.type(func(a))
         else:

--- a/dask_ndmeasure/_utils.py
+++ b/dask_ndmeasure/_utils.py
@@ -5,6 +5,7 @@ import operator
 
 import numpy
 
+import dask
 import dask.array
 
 from . import _compat
@@ -68,13 +69,14 @@ def _ravel_shape_indices(dimensions, dtype=int, chunks=None):
     return indices
 
 
-def _labeled_comprehension_func(func,
-                                out_dtype,
-                                default,
-                                a,
-                                positions=None):
+@dask.delayed
+def _labeled_comprehension_delayed(func,
+                                   out_dtype,
+                                   default,
+                                   a,
+                                   positions=None):
     """
-    Wrapped labeled comprehension function
+    Wrapped delayed labeled comprehension function
 
     Included in the module for pickling purposes. Also handle cases where
     computation should not occur.
@@ -89,3 +91,27 @@ def _labeled_comprehension_func(func,
             return out_dtype.type(func(a, positions))
     else:
         return out_dtype.type(default)
+
+
+def _labeled_comprehension_func(func,
+                                out_dtype,
+                                default,
+                                a,
+                                positions=None):
+    """
+    Wrapped labeled comprehension function
+
+    Ensures the result is a proper Dask Array and the computation delayed.
+    """
+
+    out_dtype = numpy.dtype(out_dtype)
+
+    result = dask.array.from_delayed(
+        _labeled_comprehension_delayed(
+            func, out_dtype, default, a, positions
+        ),
+        tuple(),
+        out_dtype
+    )
+
+    return result

--- a/dask_ndmeasure/_utils.py
+++ b/dask_ndmeasure/_utils.py
@@ -72,8 +72,8 @@ def _labeled_comprehension_func(func,
                                 out_dtype,
                                 default,
                                 compute,
-                                *args,
-                                **kwargs):
+                                a,
+                                positions=None):
     """
     Wrapped labeled comprehension function
 
@@ -84,6 +84,9 @@ def _labeled_comprehension_func(func,
     out_dtype = numpy.dtype(out_dtype)
 
     if compute:
-        return out_dtype.type(func(*args, **kwargs))
+        if positions is None:
+            return out_dtype.type(func(a))
+        else:
+            return out_dtype.type(func(a, positions))
     else:
         return out_dtype.type(default)


### PR DESCRIPTION
Simplifies and optimizes `labeled_comprehension` a bit. Should help it run a bit faster, make the code a bit cleaner, and a bit easier to understand.

* Removes the need for a `compute` argument in the delayed function wrapper.
* Drops computation of `any` on label matches.
* Moves initial argument packing out of the `for`-loop.
* Construct positions only when the user provided function takes them.
* Refactor out `delayed` code in `_utils` and use `delayed` decorator.
* Creates a utility function for turning user function call into Dask Array.