### PR TITLE
Optimization tweaks to labeled_comprehension

### DIFF
--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -166,7 +166,7 @@ def labeled_comprehension(input,
         input, labels, index
     )
     out_dtype = numpy.dtype(out_dtype)
-    default = numpy.array(default, dtype=out_dtype)[()]
+    default = out_dtype.type(default)
     pass_positions = bool(pass_positions)
 
     lbl_mtch = _utils._get_label_matches(labels, index)

--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -182,7 +182,8 @@ def labeled_comprehension(input,
 
     result = numpy.empty(index.shape, dtype=object)
     for i in itertools.product(*index_ranges):
-        args_lbl_mtch_i = tuple(e[lbl_mtch[i]] for e in args)
+        lbl_mtch_i = lbl_mtch[i]
+        args_lbl_mtch_i = tuple(e[lbl_mtch_i] for e in args)
         result[i] = _utils._labeled_comprehension_func(
             func, out_dtype, default, *args_lbl_mtch_i
         )

--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -178,17 +178,19 @@ def labeled_comprehension(input,
         )
         args = (input, positions)
 
+    index_ranges = [_pycompat.irange(e) for e in index.shape]
+
     result = numpy.empty(index.shape, dtype=object)
-    for i in itertools.product(*[_pycompat.irange(j) for j in index.shape]):
+    for i in itertools.product(*index_ranges):
         args_lbl_mtch_i = tuple(e[lbl_mtch[i]] for e in args)
         result[i] = _utils._labeled_comprehension_func(
             func, out_dtype, default, *args_lbl_mtch_i
         )
 
     for i in _pycompat.irange(result.ndim - 1, -1, -1):
-        p = itertools.product(*[_pycompat.irange(e) for e in index.shape[:i]])
+        index_ranges_i = itertools.product(*(index_ranges[:i]))
         result2 = result[..., 0]
-        for j in p:
+        for j in index_ranges_i:
             result2[j] = dask.array.stack(result[j].tolist(), axis=0)
         result = result2
     result = result[()]

--- a/dask_ndmeasure/_utils.py
+++ b/dask_ndmeasure/_utils.py
@@ -82,8 +82,6 @@ def _labeled_comprehension_delayed(func,
     computation should not occur.
     """
 
-    out_dtype = numpy.dtype(out_dtype)
-
     if a.size:
         if positions is None:
             return out_dtype.type(func(a))
@@ -103,8 +101,6 @@ def _labeled_comprehension_func(func,
 
     Ensures the result is a proper Dask Array and the computation delayed.
     """
-
-    out_dtype = numpy.dtype(out_dtype)
 
     result = dask.array.from_delayed(
         _labeled_comprehension_delayed(

--- a/dask_ndmeasure/_utils.py
+++ b/dask_ndmeasure/_utils.py
@@ -102,12 +102,10 @@ def _labeled_comprehension_func(func,
     Ensures the result is a proper Dask Array and the computation delayed.
     """
 
-    result = dask.array.from_delayed(
+    return dask.array.from_delayed(
         _labeled_comprehension_delayed(
             func, out_dtype, default, a, positions
         ),
         tuple(),
         out_dtype
     )
-
-    return result

--- a/dask_ndmeasure/_utils.py
+++ b/dask_ndmeasure/_utils.py
@@ -88,7 +88,7 @@ def _labeled_comprehension_delayed(func,
         else:
             return out_dtype.type(func(a, positions))
     else:
-        return out_dtype.type(default)
+        return default
 
 
 def _labeled_comprehension_func(func,


### PR DESCRIPTION
Various minor tweaks to `labeled_comprehension`. These streamline the code a bit by dropping extra checks from internal functions and storing reused quantities to avoid recomputation. None of them appear to have a pronounced effect, but they are still good changes nevertheless.