### PR TITLE
Rewrite maximum and minimum to use labeled_comprehension

### DIFF
--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -417,23 +417,9 @@ def minimum(input, labels=None, index=None):
         input, labels, index
     )
 
-    lbl_mtch = _utils._get_label_matches(labels, index)
-
-    lbl_mtch_any = lbl_mtch.any(
-        axis=tuple(_pycompat.irange(index.ndim, lbl_mtch.ndim))
+    return labeled_comprehension(
+        input, labels, index, numpy.min, input.dtype, input.dtype.type(0)
     )
-
-    input_mtch = dask.array.where(
-        lbl_mtch, input[index.ndim * (None,)], numpy.nan
-    )
-
-    nanmin_lbl = dask.array.nanmin(
-        input_mtch, axis=tuple(_pycompat.irange(index.ndim, input_mtch.ndim))
-    )
-
-    min_lbl = dask.array.where(lbl_mtch_any, nanmin_lbl, 0).astype(input.dtype)
-
-    return min_lbl
 
 
 def minimum_position(input, labels=None, index=None):

--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -232,23 +232,9 @@ def maximum(input, labels=None, index=None):
         input, labels, index
     )
 
-    lbl_mtch = _utils._get_label_matches(labels, index)
-
-    lbl_mtch_any = lbl_mtch.any(
-        axis=tuple(_pycompat.irange(index.ndim, lbl_mtch.ndim))
+    return labeled_comprehension(
+        input, labels, index, numpy.max, input.dtype, input.dtype.type(0)
     )
-
-    input_mtch = dask.array.where(
-        lbl_mtch, input[index.ndim * (None,)], numpy.nan
-    )
-
-    nanmax_lbl = dask.array.nanmax(
-        input_mtch, axis=tuple(_pycompat.irange(index.ndim, input_mtch.ndim))
-    )
-
-    max_lbl = dask.array.where(lbl_mtch_any, nanmax_lbl, 0).astype(input.dtype)
-
-    return max_lbl
 
 
 def maximum_position(input, labels=None, index=None):


### PR DESCRIPTION
At this point a `labeled_comprehension` based implementation of `maximum` and `minimum`, is faster than the `nan`-based implementation that was here previously. It's not a huge speed up, but is ~10% faster. Also switching to `labeled_comprehension` cuts down on code complexity, improves test coverage of `labeled_comprehension`, and it avoids some questions that the `nan` based implementation raised (e.g. how to handle `nan` in the selected region). So this is a nice improvement all-around.