### PR TITLE
Add median

### DIFF
--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -370,6 +370,44 @@ def mean(input, labels=None, index=None):
     return com_lbl
 
 
+def median(input, labels=None, index=None):
+    """
+    Calculate the median of the values of an array over labeled regions.
+
+    Parameters
+    ----------
+    input : array_like
+        Array_like of values. For each region specified by `labels`, the
+        median value of `input` over the region is computed.
+    labels : array_like, optional
+        An array_like of integers marking different regions over which the
+        median value of `input` is to be computed. `labels` must have the
+        same shape as `input`. If `labels` is not specified, the median
+        over the whole array is returned.
+    index : array_like, optional
+        A list of region labels that are taken into account for computing the
+        medians. If index is None, the median over all elements where `labels`
+        is non-zero is returned.
+
+    Returns
+    -------
+    median : float or list of floats
+        List of medians of `input` over the regions determined by `labels` and
+        whose index is in `index`. If `index` or `labels` are not specified, a
+        float is returned: the median value of `input` if `labels` is None,
+        and the median value of elements where `labels` is greater than zero
+        if `index` is None.
+    """
+
+    input, labels, index = _utils._norm_input_labels_index(
+        input, labels, index
+    )
+
+    return labeled_comprehension(
+        input, labels, index, numpy.median, input.dtype, input.dtype.type(0)
+    )
+
+
 def minimum(input, labels=None, index=None):
     """
     Calculate the minimum of the values of an array over labeled regions.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -22,6 +22,7 @@ import dask_ndmeasure._test_utils
         "maximum",
         "maximum_position",
         "mean",
+        "median",
         "minimum",
         "minimum_position",
         "standard_deviation",
@@ -55,6 +56,7 @@ def test_measure_props_err(funcname):
         "maximum",
         "maximum_position",
         "mean",
+        "median",
         "minimum",
         "minimum_position",
         "standard_deviation",
@@ -104,6 +106,14 @@ def test_measure_props(funcname, shape, chunks, has_lbls, ind):
 
     assert a_r.dtype == d_r.dtype
     assert a_r.shape == d_r.shape
+
+    # See the linked issue for details.
+    # ref: https://github.com/scipy/scipy/issues/7706
+    if (funcname == "median" and
+        ind is not None and
+        not np.in1d(np.atleast_1d(ind), lbls).all()):
+        pytest.skip("SciPy's `median` mishandles missing labels.")
+
     assert np.allclose(np.array(a_r), np.array(d_r), equal_nan=True)
 
 


### PR DESCRIPTION
Partially addresses issue ( https://github.com/dask-image/dask-ndmeasure/issues/2 ).

Adds a Dask Array function to compute the [median]( https://docs.scipy.org/doc/scipy-0.19.0/reference/generated/scipy.ndimage.median.html ). Tries to mimic the SciPy implementation as closely as possible. However it deviates slightly on the output format. Here we provide one array for all of the data; whereas, SciPy has some mixture of arrays and lists in the result.