### PR TITLE
Use float64 in median always

### DIFF
--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -403,8 +403,10 @@ def median(input, labels=None, index=None):
         input, labels, index
     )
 
+    nan = numpy.float64(numpy.nan)
+
     return labeled_comprehension(
-        input, labels, index, numpy.median, numpy.float64, numpy.float64(0)
+        input, labels, index, numpy.median, numpy.float64, nan
     )
 
 

--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -404,7 +404,7 @@ def median(input, labels=None, index=None):
     )
 
     return labeled_comprehension(
-        input, labels, index, numpy.median, input.dtype, input.dtype.type(0)
+        input, labels, index, numpy.median, numpy.float64, numpy.float64(0)
     )
 
 


### PR DESCRIPTION
Seems SciPy's `median` always uses `float64`. Also the default value when labels are missing should be `nan` to be consistent with NumPy's `median` and SciPy (when it is consistent). Thus we make these changes here.