### PR TITLE
Add histogram

### DIFF
--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -118,6 +118,62 @@ def extrema(input, labels=None, index=None):
     return min_lbl, max_lbl, min_pos_lbl, max_pos_lbl
 
 
+def histogram(input,
+              min,
+              max,
+              bins,
+              labels=None,
+              index=None):
+    """
+    Calculate the histogram of the values of an array, optionally at labels.
+
+    Histogram calculates the frequency of values in an array within bins
+    determined by `min`, `max`, and `bins`. The `labels` and `index`
+    keywords can limit the scope of the histogram to specified sub-regions
+    within the array.
+
+    Parameters
+    ----------
+    input : array_like
+        Data for which to calculate histogram.
+    min, max : int
+        Minimum and maximum values of range of histogram bins.
+    bins : int
+        Number of bins.
+    labels : array_like, optional
+        Labels for objects in `input`.
+        If not None, must be same shape as `input`.
+    index : int or sequence of ints, optional
+        Label or labels for which to calculate histogram. If None, all values
+        where label is greater than zero are used
+
+    Returns
+    -------
+    hist : ndarray
+        Histogram counts.
+    """
+
+    input, labels, index = _utils._norm_input_labels_index(
+        input, labels, index
+    )
+    min = numpy.int64(min)
+    max = numpy.int64(max)
+    bins = int(bins)
+
+    lbl_mtch = _utils._get_label_matches(labels, index)
+
+    index_ranges = [_pycompat.irange(e) for e in index.shape]
+
+    result = numpy.empty(index.shape, dtype=object)
+    for i in itertools.product(*index_ranges):
+        result[i] = _utils._histogram(
+            input[lbl_mtch[i]], min, max, bins
+        )
+    result = result[()]
+
+    return result
+
+
 def labeled_comprehension(input,
                           labels,
                           index,

--- a/dask_ndmeasure/_utils.py
+++ b/dask_ndmeasure/_utils.py
@@ -70,6 +70,23 @@ def _ravel_shape_indices(dimensions, dtype=int, chunks=None):
 
 
 @dask.delayed
+def _histogram(input,
+               min,
+               max,
+               bins):
+    """
+    Delayed wrapping of NumPy's histogram
+
+    Also reformats the arguments.
+    """
+
+    if input.size:
+        return numpy.histogram(input, bins, (min, max))[0]
+    else:
+        return None
+
+
+@dask.delayed
 def _labeled_comprehension_delayed(func,
                                    out_dtype,
                                    default,


### PR DESCRIPTION
Partially addresses issue ( https://github.com/dask-image/dask-ndmeasure/issues/2 ).

Adds a Dask Array function to compute the [histogram]( https://docs.scipy.org/doc/scipy-0.19.0/reference/generated/scipy.ndimage.histogram.html ). Tries to mimic the SciPy implementation as closely as possible.

As the SciPy implementation sometimes returns `None`, we need to actually return Delayed objects instead of Dask Arrays to do the same. So that is what is provided here. Tests verify this works.