### PR TITLE
Use Python int's for position functions

### DIFF
--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -421,7 +421,7 @@ def maximum_position(input, labels=None, index=None):
             axis=tuple(_pycompat.irange(index.ndim, max_lbl_indices.ndim))
         ),
         0
-    ).astype(numpy.int64)
+    ).astype(indices.dtype)
 
     max_pos_lbl = []
     max_1dpos_lbl_rem = max_1dpos_lbl
@@ -629,7 +629,7 @@ def minimum_position(input, labels=None, index=None):
             axis=tuple(_pycompat.irange(index.ndim, min_lbl_indices.ndim))
         ),
         0
-    ).astype(numpy.int64)
+    ).astype(indices.dtype)
 
     min_pos_lbl = []
     min_1dpos_lbl_rem = min_1dpos_lbl

--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -393,7 +393,7 @@ def maximum_position(input, labels=None, index=None):
         index = index.flatten()
 
     indices = _utils._ravel_shape_indices(
-        input.shape, dtype=numpy.int64, chunks=input.chunks
+        input.shape, chunks=input.chunks
     )
 
     max_lbl = maximum(input, labels=labels, index=index)
@@ -601,7 +601,7 @@ def minimum_position(input, labels=None, index=None):
         index = index.flatten()
 
     indices = _utils._ravel_shape_indices(
-        input.shape, dtype=numpy.int64, chunks=input.chunks
+        input.shape, chunks=input.chunks
     )
 
     min_lbl = minimum(input, labels=labels, index=index)

--- a/dask_ndmeasure/_compat.py
+++ b/dask_ndmeasure/_compat.py
@@ -117,7 +117,7 @@ def _argwhere(a):
 
     nz = _isnonzero(a).flatten()
 
-    ind = _indices(a.shape, dtype=numpy.int64, chunks=a.chunks)
+    ind = _indices(a.shape, chunks=a.chunks)
     if ind.ndim > 1:
         ind = dask.array.stack(
             [ind[i].ravel() for i in _pycompat.irange(len(ind))], axis=1


### PR DESCRIPTION
To improve compatibility with SciPy functions on Windows, use Python `int`s for `argwhere`, `minimum_position`, and `maximum_position`. This ensure that the precision matches that used on Windows, but maintains the same precision on Unix.