### PR TITLE
Fix default index test

### DIFF
--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -54,7 +54,7 @@ def test__norm_input_labels_index():
 
     dau.assert_eq(d_n, d)
     dau.assert_eq(d_lbls_n, d_lbls)
-    dau.assert_eq(ind_n, np.array([1], dtype=np.int64))
+    dau.assert_eq(ind_n, np.array([1], dtype=int))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fix the expected array type for a default index. This change is a consequence of PR ( https://github.com/dask-image/dask-ndmeasure/pull/61 ). However as `int` and `int64` are the same on 64-bit Unix, the issue doesn't show up there. Instead the issue only shows up on Windows. Hence we make this fix for Windows.