### PR TITLE
Use intp for positions

### DIFF
--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -393,7 +393,7 @@ def maximum_position(input, labels=None, index=None):
         index = index.flatten()
 
     indices = _utils._ravel_shape_indices(
-        input.shape, chunks=input.chunks
+        input.shape, dtype=numpy.intp, chunks=input.chunks
     )
 
     max_lbl = maximum(input, labels=labels, index=index)

--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -59,7 +59,7 @@ def center_of_mass(input, labels=None, index=None):
     input_mtch_sum = sum(input, labels, index)
 
     input_i = _compat._indices(
-        input.shape, chunks=input.chunks
+        input.shape, dtype=numpy.intp, chunks=input.chunks
     )
 
     input_i_wt = input[None] * input_i

--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -601,7 +601,7 @@ def minimum_position(input, labels=None, index=None):
         index = index.flatten()
 
     indices = _utils._ravel_shape_indices(
-        input.shape, chunks=input.chunks
+        input.shape, dtype=numpy.intp, chunks=input.chunks
     )
 
     min_lbl = minimum(input, labels=labels, index=index)


### PR DESCRIPTION
It seems that SciPy is making use of the `size` property of NumPy arrays when constructing indices to use in position functions. From looking through the NumPy code, it appears that `size` always has a type of `intp`. So we make use of `intp` in all functions returning position. This way we should return a result that is consistent with SciPy. This ends up being the same on 64-bit Unixes, but does make a difference on Windows.