### PR TITLE
Fix label test with default index

### DIFF
--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -41,7 +41,7 @@ def test__norm_input_labels_index():
     a = np.random.random(shape)
     d = da.from_array(a, chunks=chunks)
 
-    lbls = (a < 0.5).astype(np.int64)
+    lbls = (a < 0.5).astype(int)
     d_lbls = da.from_array(lbls, chunks=d.chunks)
 
     d_n, d_lbls_n, ind_n = dask_ndmeasure._utils._norm_input_labels_index(


### PR DESCRIPTION
Fix the expected array type for labels with a default index. This change is a consequence of PR ( https://github.com/dask-image/dask-ndmeasure/pull/61 ). However as `int` and `int64` are the same on 64-bit Unix, the issue doesn't show up there. Instead the issue only shows up on Windows. Hence we make this fix for Windows.