### PR TITLE
Warn on N-D index

### DIFF
--- a/dask_ndmeasure/_utils.py
+++ b/dask_ndmeasure/_utils.py
@@ -2,6 +2,7 @@
 
 
 import operator
+import warnings
 
 import numpy
 
@@ -29,6 +30,12 @@ def _norm_input_labels_index(input, labels=None, index=None):
 
     labels = _compat._asarray(labels)
     index = _compat._asarray(index)
+
+    if index.ndim > 1:
+        warnings.warn(
+            "Having index with dimensionality greater than 1 is undefined.",
+            FutureWarning
+        )
 
     if input.shape != labels.shape:
         raise ValueError("The input and labels arrays must be the same shape.")


### PR DESCRIPTION
Fixes https://github.com/dask-image/dask-ndmeasure/issues/47

When any function gets an N-D `index` argument with `N > 1`, issue a `FutureWarning` indicating that this behavior is undefined and subject to change. In addition, include a test to ensure the `FutureWarning` is appropriately raised if `index` has `N > 1` and not if `N == 1 or N == 0`.