### PR TITLE
Simplify handling of default labels and index

### DIFF
--- a/dask_ndmeasure/_utils.py
+++ b/dask_ndmeasure/_utils.py
@@ -21,10 +21,9 @@ def _norm_input_labels_index(input, labels=None, index=None):
     input = _compat._asarray(input)
 
     if labels is None:
-        labels = (input != 0).astype(int)
-        index = None
-
-    if index is None:
+        labels = dask.array.ones(input.shape, dtype=int, chunks=input.chunks)
+        index = dask.array.ones(tuple(), dtype=int, chunks=tuple())
+    elif index is None:
         labels = (labels > 0).astype(int)
         index = dask.array.ones(tuple(), dtype=int, chunks=tuple())
 


### PR DESCRIPTION
Avoid performing extra computations on the default cases of `labels` and `index` by simply filling them with their default values. Also most SciPy documentation mentions that `labels` defaults to the whole image. We have been restricting it to the non-zero portion, but that is technically incorrect. Changing it to be the whole image hasn't had any negative effects before, but we go ahead and do it now to match SciPy's docs more accurately.