### PR TITLE
Optimizations for minimum_position and maximum_position

### DIFF
--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -13,7 +13,6 @@ del get_versions
 
 
 import itertools
-import operator
 
 import numpy
 import scipy.ndimage

--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -379,36 +379,9 @@ def maximum_position(input, labels=None, index=None):
     if index.shape:
         index = index.flatten()
 
-    indices = _utils._ravel_shape_indices(
-        input.shape, chunks=input.chunks
+    max_1dpos_lbl = labeled_comprehension(
+        input, labels, index, _utils._argmax, int, 0, pass_positions=True
     )
-
-    max_lbl = maximum(input, labels=labels, index=index)
-
-    lbl_mtch = _utils._get_label_matches(labels, index)
-    input_mtch = dask.array.where(
-        lbl_mtch, input[index.ndim * (None,)], numpy.nan
-    )
-
-    max_lbl_mask = operator.eq(
-        max_lbl[max_lbl.ndim * (slice(None),) + input.ndim * (None,)],
-        input_mtch
-    )
-    max_lbl_mask_any = max_lbl_mask.any(
-        axis=tuple(_pycompat.irange(index.ndim, max_lbl_mask.ndim))
-    )
-    max_lbl_indices = dask.array.where(
-        max_lbl_mask, indices, numpy.nan
-    )
-
-    max_1dpos_lbl = dask.array.where(
-        max_lbl_mask_any,
-        dask.array.nanmin(
-            max_lbl_indices,
-            axis=tuple(_pycompat.irange(index.ndim, max_lbl_indices.ndim))
-        ),
-        0
-    ).astype(indices.dtype)
 
     if not max_1dpos_lbl.ndim:
         max_1dpos_lbl = max_1dpos_lbl[None]

--- a/dask_ndmeasure/__init__.py
+++ b/dask_ndmeasure/__init__.py
@@ -534,36 +534,9 @@ def minimum_position(input, labels=None, index=None):
     if index.shape:
         index = index.flatten()
 
-    indices = _utils._ravel_shape_indices(
-        input.shape, chunks=input.chunks
+    min_1dpos_lbl = labeled_comprehension(
+        input, labels, index, _utils._argmin, int, 0, pass_positions=True
     )
-
-    min_lbl = minimum(input, labels=labels, index=index)
-
-    lbl_mtch = _utils._get_label_matches(labels, index)
-    input_mtch = dask.array.where(
-        lbl_mtch, input[index.ndim * (None,)], numpy.nan
-    )
-
-    min_lbl_mask = operator.eq(
-        min_lbl[min_lbl.ndim * (slice(None),) + input.ndim * (None,)],
-        input_mtch
-    )
-    min_lbl_mask_any = min_lbl_mask.any(
-        axis=tuple(_pycompat.irange(index.ndim, min_lbl_mask.ndim))
-    )
-    min_lbl_indices = dask.array.where(
-        min_lbl_mask, indices, numpy.nan
-    )
-
-    min_1dpos_lbl = dask.array.where(
-        min_lbl_mask_any,
-        dask.array.nanmin(
-            min_lbl_indices,
-            axis=tuple(_pycompat.irange(index.ndim, min_lbl_indices.ndim))
-        ),
-        0
-    ).astype(indices.dtype)
 
     if not min_1dpos_lbl.ndim:
         min_1dpos_lbl = min_1dpos_lbl[None]

--- a/dask_ndmeasure/_utils.py
+++ b/dask_ndmeasure/_utils.py
@@ -75,6 +75,14 @@ def _ravel_shape_indices(dimensions, dtype=int, chunks=None):
     return indices
 
 
+def _argmax(a, positions):
+    """
+    Find original array position corresponding to the maximum.
+    """
+
+    return positions[numpy.argmax(a)]
+
+
 @dask.delayed
 def _histogram(input,
                min,

--- a/dask_ndmeasure/_utils.py
+++ b/dask_ndmeasure/_utils.py
@@ -83,6 +83,14 @@ def _argmax(a, positions):
     return positions[numpy.argmax(a)]
 
 
+def _argmin(a, positions):
+    """
+    Find original array position corresponding to the minimum.
+    """
+
+    return positions[numpy.argmin(a)]
+
+
 @dask.delayed
 def _histogram(input,
                min,


### PR DESCRIPTION
Fixes https://github.com/dask-image/dask-ndmeasure/issues/74

Rewrites `minimum_position` and `maximum_position` to use their own `labeled_comprehension` functions. This ends up being significantly simpler and runs ~33% faster than the original implementation.