### PR TITLE
Use iterable range in core tests

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -17,6 +17,12 @@ import dask.array as da
 import dask_ndmeasure
 
 
+try:
+    irange = xrange
+except NameError:
+    irange = range
+
+
 @pytest.mark.parametrize(
     "funcname", [
         "center_of_mass",
@@ -164,7 +170,7 @@ def test_extrema(shape, chunks, has_lbls, ind):
 
     assert len(a_r) == len(d_r)
 
-    for i in range(len(a_r)):
+    for i in irange(len(a_r)):
         a_r_i = np.array(a_r[i])
         if a_r_i.dtype != d_r[i].dtype:
             wrn.warn(
@@ -225,7 +231,7 @@ def test_histogram(shape, chunks, has_lbls, ind, min, max, bins):
     else:
         assert a_r.dtype == d_r.dtype
         assert a_r.shape == d_r.shape
-        for i in it.product(*[range(_) for _ in a_r.shape]):
+        for i in it.product(*[irange(_) for _ in a_r.shape]):
             if a_r[i] is None:
                 assert d_r[i].compute() is None
             else:


### PR DESCRIPTION
Was using `range` on both Python 2 and Python 3. The problem being that on Python 2 this allocates a `list` with the contents of everything included by `range`'s bounds and step size. To fix this, simply use a Python 2/3 compatibility trick to get an iterable range on Python 2. Behavior on Python 3 is unchanged (excepting an alias).